### PR TITLE
Add entrypoint to station registration (backend to weewx PR 705)

### DIFF
--- a/register/mkstations.pl
+++ b/register/mkstations.pl
@@ -121,12 +121,12 @@ if ($dbh) {
 #	my $qry = "select station_url,description,latitude,longitude,station_type,last_seen from (select * from stations order by last_seen asc) t1 where t1.last_seen > $cutoff group by t1.station_url";
         # since doing it in the db query does not work, query for everything
         # then do the filtering in perl.  sigh.
-    my $qry = "select station_url,description,latitude,longitude,station_type,station_model,last_seen,weewx_info from stations where last_seen > $cutoff order by last_seen";
+    my $qry = "select station_url,description,latitude,longitude,station_type,station_model,last_seen,weewx_info,entrypoint from stations where last_seen > $cutoff order by last_seen";
     my $sth = $dbh->prepare($qry);
     if ($sth) {
 	my %unique;
 	$sth->execute();
-	$sth->bind_columns(\my($url,$desc,$lat,$lon,$st,$sm,$ts,$ver));
+	$sth->bind_columns(\my($url,$desc,$lat,$lon,$st,$sm,$ts,$ver,$ep));
 	while($sth->fetch()) {
 	    my %r;
 	    $r{url} = $url;
@@ -137,6 +137,7 @@ if ($dbh) {
             $r{station_model} = $sm;
 	    $r{last_seen} = $ts;
 	    $r{weewx_info} = $ver;
+	    $r{entrypoint} = $ep;
 	    $r{sort_key} = $COLLATOR->getSortKey(trim($desc));
 	    if(!defined($unique{$url}) || $ts>$unique{$url}->{last_seen}) {
 		$unique{$url} = \%r;
@@ -175,6 +176,7 @@ if(open(OFILE,">$tmpfile")) {
                 print OFILE "    station: \"$rec->{station_type}\",\n";
                 print OFILE "    model: \"$rec->{station_model}\",\n";
                 print OFILE "    weewx_info: \"$rec->{weewx_info}\",\n";
+                print OFILE "    entrypoint: \"$rec->{entrypoint}\",\n";
                 print OFILE "    last_seen: $rec->{last_seen} },\n";
                 print OFILE "\n";
             }

--- a/register/mkstations.pl
+++ b/register/mkstations.pl
@@ -121,12 +121,12 @@ if ($dbh) {
 #	my $qry = "select station_url,description,latitude,longitude,station_type,last_seen from (select * from stations order by last_seen asc) t1 where t1.last_seen > $cutoff group by t1.station_url";
         # since doing it in the db query does not work, query for everything
         # then do the filtering in perl.  sigh.
-    my $qry = "select station_url,description,latitude,longitude,station_type,station_model,last_seen,weewx_info,entrypoint from stations where last_seen > $cutoff order by last_seen";
+    my $qry = "select station_url,description,latitude,longitude,station_type,station_model,last_seen,weewx_info,config_path from stations where last_seen > $cutoff order by last_seen";
     my $sth = $dbh->prepare($qry);
     if ($sth) {
 	my %unique;
 	$sth->execute();
-	$sth->bind_columns(\my($url,$desc,$lat,$lon,$st,$sm,$ts,$ver,$ep));
+	$sth->bind_columns(\my($url,$desc,$lat,$lon,$st,$sm,$ts,$ver,$cp));
 	while($sth->fetch()) {
 	    my %r;
 	    $r{url} = $url;
@@ -137,7 +137,7 @@ if ($dbh) {
             $r{station_model} = $sm;
 	    $r{last_seen} = $ts;
 	    $r{weewx_info} = $ver;
-	    $r{entrypoint} = $ep;
+	    $r{config_path} = $cp;
 	    $r{sort_key} = $COLLATOR->getSortKey(trim($desc));
 	    if(!defined($unique{$url}) || $ts>$unique{$url}->{last_seen}) {
 		$unique{$url} = \%r;
@@ -176,7 +176,7 @@ if(open(OFILE,">$tmpfile")) {
                 print OFILE "    station: \"$rec->{station_type}\",\n";
                 print OFILE "    model: \"$rec->{station_model}\",\n";
                 print OFILE "    weewx_info: \"$rec->{weewx_info}\",\n";
-                print OFILE "    entrypoint: \"$rec->{entrypoint}\",\n";
+                print OFILE "    config_path: \"$rec->{config_path}\",\n";
                 print OFILE "    last_seen: $rec->{last_seen} },\n";
                 print OFILE "\n";
             }

--- a/register/readme
+++ b/register/readme
@@ -55,7 +55,7 @@ To set up a clean raspberry pi with mysql, apache2, and the registration cgi:
 
 1) install the required rpms
 
-apt-get install libdbd-sqlite3-perl libdbd-mysal-perl mariadb-server
+apt-get install libdbd-sqlite3-perl libdbd-mysql-perl mariadb-server
 
 2)  create a /etc/weereg/dbinfo file ala the following example,
     substituting in your desired values
@@ -73,8 +73,12 @@ service apache2 reload
 
 4) set up mariadb user and database
 
+mysql -u root -p
+<enter mysql root password>
+create database weewx
+source weereg.sql
 create user 'weewx'@'localhost' identified by 'weewx';
-create database weeex;
+create database weewx;
 grant all privileges on weewx.* to 'weewx'@'localhost';
 
 5) install the registration code and pages
@@ -87,11 +91,19 @@ copy everything else to /var/www/html/register
 crontab -u www-data crontab.reg
 and 'crontab -e' to edit the paths therein to taste
 
-
 7a) test the registration - register a system
 
-curl 'curl 'http://127.0.0.1/cgi-bin/register.cgi?station_url=http%3A%2F%2Fwww.somedomain.com&description=My+Little+Town%2C+Oregon&latitude=-71.123&longitude=123.345&station_type=whatever&station_model=something&python_info=3.7.1&platform_info=Linux-4.19.0-16-amd64-x86_64-with-debian-10.11'
+#
+# the url here has to have execCGI set
+# the actual one weewx uses is http://www.weewx.com/register/register.cgi
+#
+curl 'http://www.weewx.com/cgi-bin/register.cgi?station_url=http%3A%2F%2Fwww.mydomain.com&description=My+Little+Town%2C+Oregon&latitude=-71.123&longitude=123.345&station_type=whatever&station_model=something&python_info=3.7.1&platform_info=Linux-4.19.0-16-amd64-x86_64-with-debian-10.11&config_path=%2Fhome%2Fweewx%2Fweewx.conf' > /tmp/testing 2>/tmp/testing.err
 
+a successful registration will be indicated in the scratch file /tmp/testing
+with error output in /tmp/testing.err
+
+to zero the db out, rerun 'source weereg.sql'
+and potentially restart weewx to zero its timer
 
 7b) verify the database shows the newly registered system
 
@@ -106,17 +118,13 @@ Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.
 Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
 
 MariaDB [(none)]> use weewx
-Reading table information for completion of table and column names
-You can turn off this feature to get a quicker startup with -A
-
-Database changed
 MariaDB [weewx]> select * from stations;
-+-------------------------------+------------------------+----------+-----------+--------------+---------------+------------+-------------+------------------------------------------------+--------------------+-----------+------------+
-| station_url                   | description            | latitude | longitude | station_type | station_model | weewx_info | python_info | platform_info                                  | entrypoint         | last_addr | last_seen  |
-+-------------------------------+------------------------+----------+-----------+--------------+---------------+------------+-------------+------------------------------------------------+--------------------+-----------+------------+
-| http://www23.example123a.com  | My Little Town, Oregon |  -11.123 |   112.345 | whatever     | Something2    | NULL       | 3.7.0       | Linux-4.19.0-16-amd64-x86_64-with-debian-10.11 | /usr/bin/weewxd    | 127.0.0.1 | 1634352207 |
-+-------------------------------+------------------------+----------+-----------+--------------+---------------+------------+-------------+------------------------------------------------+--------------------+-----------+------------+
-3 rows in set (0.000 sec)
++-------------------------------+------------------------+----------+-----------+--------------+---------------+------------+-------------+------------------------------------------------+------------------------+-----------+------------+
+| station_url                   | description            | latitude | longitude | station_type | station_model | weewx_info | python_info | platform_info                                  | config_path            | last_addr | last_seen  |
++-------------------------------+------------------------+----------+-----------+--------------+---------------+------------+-------------+------------------------------------------------+------------------------+-----------+------------+
+| http://www.somedomain.com     | My Little Town, Oregon |  -71.123 |   123.345 | whatever     | something     | NULL       | 3.7.1       | Linux-4.19.0-16-amd64-x86_64-with-debian-10.11 | /home/weewx/weewx.conf | 127.0.0.1 | 1664920923 |
++-------------------------------+------------------------+----------+-----------+--------------+---------------+------------+-------------+------------------------------------------------+------------------------+-----------+------------+
+1 rows in set (0.000 sec)
 
 MariaDB [weewx]> exit
 

--- a/register/readme
+++ b/register/readme
@@ -44,3 +44,79 @@ chown www-data /var/lib/weewx
 4) configure crontab to generate the html page
 
 crontab -u www-data crontab.reg
+
+
+#-----------------------------------------------
+#----------- vds updates 2021-1015 -------------
+#----------- for raspberry pi os   -------------
+#-----------------------------------------------
+
+To set up a clean raspberry pi with mysql, apache2, and the registration cgi:
+
+1) install the required rpms
+
+apt-get install libdbd-sqlite3-perl libdbd-mysal-perl mariadb-server
+
+2)  create a /etc/weereg/dbinfo file ala the following example,
+    substituting in your desired values
+
+dbhost=localhost
+dbname=weewx
+dbuser=weewx
+dbpass=weewx
+
+3) enable cgi in apache2
+
+cd /etc/apache2/mods-enabled
+ln -s ../mods-available/cgi.load
+service apache2 reload
+
+4) set up mariadb user and database
+
+create user 'weewx'@'localhost' identified by 'weewx';
+create database weeex;
+grant all privileges on weewx.* to 'weewx'@'localhost';
+
+5) install the registration code and pages
+
+cp register.pl /usr/lib/cgi-bin
+copy everything else to /var/www/html/register
+
+6) optional - install the crontab file
+
+crontab -u www-data crontab.reg
+and 'crontab -e' to edit the paths therein to taste
+
+
+7a) test the registration - register a system
+
+curl 'curl 'http://127.0.0.1/cgi-bin/register.cgi?station_url=http%3A%2F%2Fwww.somedomain.com&description=My+Little+Town%2C+Oregon&latitude=-71.123&longitude=123.345&station_type=whatever&station_model=something&python_info=3.7.1&platform_info=Linux-4.19.0-16-amd64-x86_64-with-debian-10.11'
+
+
+7b) verify the database shows the newly registered system
+
+# mysql -u weewx -p -h localhost
+Enter password:
+Welcome to the MariaDB monitor.  Commands end with ; or \g.
+Your MariaDB connection id is 99
+Server version: 10.3.31-MariaDB-0+deb10u1 Raspbian 10
+
+Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.
+
+Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
+
+MariaDB [(none)]> use weewx
+Reading table information for completion of table and column names
+You can turn off this feature to get a quicker startup with -A
+
+Database changed
+MariaDB [weewx]> select * from stations;
++-------------------------------+------------------------+----------+-----------+--------------+---------------+------------+-------------+------------------------------------------------+--------------------+-----------+------------+
+| station_url                   | description            | latitude | longitude | station_type | station_model | weewx_info | python_info | platform_info                                  | entrypoint         | last_addr | last_seen  |
++-------------------------------+------------------------+----------+-----------+--------------+---------------+------------+-------------+------------------------------------------------+--------------------+-----------+------------+
+| http://www23.example123a.com  | My Little Town, Oregon |  -11.123 |   112.345 | whatever     | Something2    | NULL       | 3.7.0       | Linux-4.19.0-16-amd64-x86_64-with-debian-10.11 | /usr/bin/weewxd    | 127.0.0.1 | 1634352207 |
++-------------------------------+------------------------+----------+-----------+--------------+---------------+------------+-------------+------------------------------------------------+--------------------+-----------+------------+
+3 rows in set (0.000 sec)
+
+MariaDB [weewx]> exit
+

--- a/register/register.cgi
+++ b/register/register.cgi
@@ -123,7 +123,7 @@ my %PLACEHOLDERS = (
     );
 
 # parameters that we recognize
-my @params = qw(station_url description latitude longitude station_type station_model weewx_info python_info platform_info);
+my @params = qw(station_url description latitude longitude station_type station_model weewx_info python_info platform_info entrypoint);
 
 my $RMETHOD = $ENV{'REQUEST_METHOD'};
 if($RMETHOD eq 'GET' || $RMETHOD eq 'POST') {
@@ -307,7 +307,7 @@ sub registerstation {
     $rec{user_agent} = $ENV{HTTP_USER_AGENT};
 
     # do not permit stray quotes or other devious characters
-    for my $k ('station_url','station_type','description','station_model','weewx_info','python_info','platform_info') {
+    for my $k ('station_url','station_type','description','station_model','weewx_info','python_info','platform_info','entrypoint') {
         my $sanitized = sanitize($rec{$k});
         if($rec{$k} ne $sanitized) {
             logmsg("sanitized $k from '" . $rec{$k} . "' to '" . $sanitized . "'");
@@ -420,13 +420,13 @@ sub registerstation {
     # if data are different from latest record, save a new record.  otherwise
     # just update the timestamp of the matching record.
 
-    my $sth = $dbh->prepare(q{replace into stations (station_url,description,latitude,longitude,station_type,station_model,weewx_info,python_info,platform_info,last_addr,last_seen) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)});
+    my $sth = $dbh->prepare(q{replace into stations (station_url,description,latitude,longitude,station_type,station_model,weewx_info,python_info,platform_info,entrypoint,last_addr,last_seen) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)});
     if(!$sth) {
         my $msg = 'prepare failed: ' . $DBI::errstr;
         $dbh->disconnect();
         return ('FAIL', $msg, \%rec);
     }
-    $rc = $sth->execute($rec{station_url},$rec{description},$rec{latitude},$rec{longitude},$rec{station_type},$rec{station_model},$rec{weewx_info},$rec{python_info},$rec{platform_info},$rec{last_addr},$rec{last_seen});
+    $rc = $sth->execute($rec{station_url},$rec{description},$rec{latitude},$rec{longitude},$rec{station_type},$rec{station_model},$rec{weewx_info},$rec{python_info},$rec{platform_info},$rec{entrypoint},$rec{last_addr},$rec{last_seen});
     if(!$rc) {
         my $msg = 'execute failed: ' . $DBI::errstr;
         $dbh->disconnect();
@@ -478,10 +478,12 @@ sub get_summary_data {
     my @platform_info;
     my @python_info;
     my @weewx_info;
+    my @entrypoint;
     my %station_info_cnt;
     my %platform_info_cnt;
     my %python_info_cnt;
     my %weewx_info_cnt;
+    my %entrypoint_cnt;
 
     my $dbh = DBI->connect($dbstr, $dbuser, $dbpass, {RaiseError => 0});
     if (!$dbh) {
@@ -592,12 +594,25 @@ sub get_summary_data {
     $sth->finish();
     undef $sth;
 
+    $sth = $dbh->prepare("select entrypoint,count(entrypoint) from stations where last_seen > ? group by entrypoint");
+    if (!$sth) {
+        return "cannot prepare select statement: $DBI::errstr";
+    }
+    $sth->execute($cutoff);
+    $sth->bind_columns(\my($x,$y));
+    while($sth->fetch()) {
+        next if($x eq q());
+        $entrypoint_cnt{$x} = $y;
+    }
+    $sth->finish();
+    undef $sth;
+
     $dbh->disconnect();
     undef $dbh;
 
     return (q(),
-            \@station_info, \@platform_info, \@python_info, \@weewx_info,
-            \%station_info_cnt, \%platform_info_cnt, \%python_info_cnt, \%weewx_info_cnt
+            \@station_info, \@platform_info, \@python_info, \@weewx_info, \@entrypoint,
+            \%station_info_cnt, \%platform_info_cnt, \%python_info_cnt, \%weewx_info_cnt, \%entrypoint_cnt
         );
 }
 

--- a/register/register.cgi
+++ b/register/register.cgi
@@ -123,7 +123,7 @@ my %PLACEHOLDERS = (
     );
 
 # parameters that we recognize
-my @params = qw(station_url description latitude longitude station_type station_model weewx_info python_info platform_info entrypoint);
+my @params = qw(station_url description latitude longitude station_type station_model weewx_info python_info platform_info config_path);
 
 my $RMETHOD = $ENV{'REQUEST_METHOD'};
 if($RMETHOD eq 'GET' || $RMETHOD eq 'POST') {
@@ -307,7 +307,7 @@ sub registerstation {
     $rec{user_agent} = $ENV{HTTP_USER_AGENT};
 
     # do not permit stray quotes or other devious characters
-    for my $k ('station_url','station_type','description','station_model','weewx_info','python_info','platform_info','entrypoint') {
+    for my $k ('station_url','station_type','description','station_model','weewx_info','python_info','platform_info','config_path') {
         my $sanitized = sanitize($rec{$k});
         if($rec{$k} ne $sanitized) {
             logmsg("sanitized $k from '" . $rec{$k} . "' to '" . $sanitized . "'");
@@ -420,13 +420,13 @@ sub registerstation {
     # if data are different from latest record, save a new record.  otherwise
     # just update the timestamp of the matching record.
 
-    my $sth = $dbh->prepare(q{replace into stations (station_url,description,latitude,longitude,station_type,station_model,weewx_info,python_info,platform_info,entrypoint,last_addr,last_seen) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)});
+    my $sth = $dbh->prepare(q{replace into stations (station_url,description,latitude,longitude,station_type,station_model,weewx_info,python_info,platform_info,config_path,last_addr,last_seen) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)});
     if(!$sth) {
         my $msg = 'prepare failed: ' . $DBI::errstr;
         $dbh->disconnect();
         return ('FAIL', $msg, \%rec);
     }
-    $rc = $sth->execute($rec{station_url},$rec{description},$rec{latitude},$rec{longitude},$rec{station_type},$rec{station_model},$rec{weewx_info},$rec{python_info},$rec{platform_info},$rec{entrypoint},$rec{last_addr},$rec{last_seen});
+    $rc = $sth->execute($rec{station_url},$rec{description},$rec{latitude},$rec{longitude},$rec{station_type},$rec{station_model},$rec{weewx_info},$rec{python_info},$rec{platform_info},$rec{config_path},$rec{last_addr},$rec{last_seen});
     if(!$rc) {
         my $msg = 'execute failed: ' . $DBI::errstr;
         $dbh->disconnect();
@@ -478,12 +478,12 @@ sub get_summary_data {
     my @platform_info;
     my @python_info;
     my @weewx_info;
-    my @entrypoint;
+    my @config_path;
     my %station_info_cnt;
     my %platform_info_cnt;
     my %python_info_cnt;
     my %weewx_info_cnt;
-    my %entrypoint_cnt;
+    my %config_path_cnt;
 
     my $dbh = DBI->connect($dbstr, $dbuser, $dbpass, {RaiseError => 0});
     if (!$dbh) {
@@ -594,7 +594,7 @@ sub get_summary_data {
     $sth->finish();
     undef $sth;
 
-    $sth = $dbh->prepare("select entrypoint,count(entrypoint) from stations where last_seen > ? group by entrypoint");
+    $sth = $dbh->prepare("select config_path,count(config_path) from stations where last_seen > ? group by config_path");
     if (!$sth) {
         return "cannot prepare select statement: $DBI::errstr";
     }
@@ -602,7 +602,7 @@ sub get_summary_data {
     $sth->bind_columns(\my($x,$y));
     while($sth->fetch()) {
         next if($x eq q());
-        $entrypoint_cnt{$x} = $y;
+        $config_path_cnt{$x} = $y;
     }
     $sth->finish();
     undef $sth;
@@ -611,8 +611,8 @@ sub get_summary_data {
     undef $dbh;
 
     return (q(),
-            \@station_info, \@platform_info, \@python_info, \@weewx_info, \@entrypoint,
-            \%station_info_cnt, \%platform_info_cnt, \%python_info_cnt, \%weewx_info_cnt, \%entrypoint_cnt
+            \@station_info, \@platform_info, \@python_info, \@weewx_info, \@config_path,
+            \%station_info_cnt, \%platform_info_cnt, \%python_info_cnt, \%weewx_info_cnt, \%config_path_cnt
         );
 }
 

--- a/register/savecounts.pl
+++ b/register/savecounts.pl
@@ -74,17 +74,17 @@ my $errmsg = q();
 my $dbh = DBI->connect($dbstr, $dbuser, $dbpass, { RaiseError => 0 });
 if ($dbh) {
     #my $sth = $dbh->prepare("select station_url,any_value(station_type),last_seen from stations group by station_url, last_seen");
-    my $sth = $dbh->prepare("select s.station_url,s.station_type,s.weewx_info,s.python_info,s.platform_info,s.entrypoint,s.last_seen from stations s inner join(select station_url, max(last_seen) as max_last_seen from stations group by station_url) sm on s.station_url = sm.station_url and s.last_seen = sm.max_last_seen");
+    my $sth = $dbh->prepare("select s.station_url,s.station_type,s.weewx_info,s.python_info,s.platform_info,s.config_path,s.last_seen from stations inner join(select station_url, max(last_seen) as max_last_seen from stations group by station_url) sm on s.station_url = sm.station_url and s.last_seen = sm.max_last_seen");
     if ($sth) {
 	$sth->execute();
-	$sth->bind_columns(\my($url,$st,$wi,$pi,$oi,$ep,$ts));
+	$sth->bind_columns(\my($url,$st,$wi,$pi,$oi,$cp,$ts));
 	while($sth->fetch()) {
 	    my %r;
 	    $r{station_type} = $st;
             $r{weewx_info} = $wi;
             $r{python_info} = $pi;
             $r{platform_info} = $oi;
-            $r{entrypoint} = $ep;
+            $r{config_path} = $cp;
 	    $r{last_seen} = $ts;
 	    $stations{$url} = \%r;
 	}
@@ -109,7 +109,7 @@ my %attrs = (
     'weewx_info' => 'weewx_history',
     'python_info' => 'python_history',
     'platform_info' => 'platform_history',
-    'entrypoint' => 'entrypoint_history'
+    'config_path' => 'config_path_history'
 );
 
 # massage the counts into hashed active/stale lists

--- a/register/savecounts.pl
+++ b/register/savecounts.pl
@@ -74,16 +74,17 @@ my $errmsg = q();
 my $dbh = DBI->connect($dbstr, $dbuser, $dbpass, { RaiseError => 0 });
 if ($dbh) {
     #my $sth = $dbh->prepare("select station_url,any_value(station_type),last_seen from stations group by station_url, last_seen");
-    my $sth = $dbh->prepare("select s.station_url,s.station_type,s.weewx_info,s.python_info,s.platform_info,s.last_seen from stations s inner join(select station_url, max(last_seen) as max_last_seen from stations group by station_url) sm on s.station_url = sm.station_url and s.last_seen = sm.max_last_seen");
+    my $sth = $dbh->prepare("select s.station_url,s.station_type,s.weewx_info,s.python_info,s.platform_info,s.entrypoint,s.last_seen from stations s inner join(select station_url, max(last_seen) as max_last_seen from stations group by station_url) sm on s.station_url = sm.station_url and s.last_seen = sm.max_last_seen");
     if ($sth) {
 	$sth->execute();
-	$sth->bind_columns(\my($url,$st,$wi,$pi,$oi,$ts));
+	$sth->bind_columns(\my($url,$st,$wi,$pi,$oi,$ep,$ts));
 	while($sth->fetch()) {
 	    my %r;
 	    $r{station_type} = $st;
             $r{weewx_info} = $wi;
             $r{python_info} = $pi;
             $r{platform_info} = $oi;
+            $r{entrypoint} = $ep;
 	    $r{last_seen} = $ts;
 	    $stations{$url} = \%r;
 	}
@@ -107,7 +108,8 @@ my %attrs = (
     'station_type' => 'history',
     'weewx_info' => 'weewx_history',
     'python_info' => 'python_history',
-    'platform_info' => 'platform_history'
+    'platform_info' => 'platform_history',
+    'entrypoint' => 'entrypoint_history'
 );
 
 # massage the counts into hashed active/stale lists

--- a/register/stations.html.in
+++ b/register/stations.html.in
@@ -325,13 +325,13 @@ function populate_station_list(sort_metric, sort_order) {
         return compare(sites[b].weewx_info, sites[a].weewx_info); });
     }
   }
-  } else if (sort_metric == 'entrypoint') {
+  } else if (sort_metric == 'config_path') {
     if (sort_order == 'up') {
       indices.sort(function(a,b) {
-        return compare(sites[a].entrypoint, sites[b].entrypoint); });
+        return compare(sites[a].config_path, sites[b].config_path); });
     } else {
       indices.sort(function(a,b) {
-        return compare(sites[b].entrypoint, sites[a].entrypoint); });
+        return compare(sites[b].config_path, sites[a].config_path); });
     }
   }
 
@@ -353,7 +353,7 @@ function populate_station_list(sort_metric, sort_order) {
   buttons += create_buttons("Longitude", "longitude");
   buttons += create_buttons("Hardware", "station");
   buttons += create_buttons("Version", "weewx_info");
-  buttons += create_buttons("Entrypoint", "entrypoint");
+  buttons += create_buttons("Config Path", "config_path");
   buttons += create_buttons("Last Seen", "last_seen");
   buttons += '<div class="button_pair">Thumbnails<br/><input type="checkbox" onClick="toggle_thumbnails()"';
   if (showThumbs) {

--- a/register/stations.html.in
+++ b/register/stations.html.in
@@ -325,6 +325,15 @@ function populate_station_list(sort_metric, sort_order) {
         return compare(sites[b].weewx_info, sites[a].weewx_info); });
     }
   }
+  } else if (sort_metric == 'entrypoint') {
+    if (sort_order == 'up') {
+      indices.sort(function(a,b) {
+        return compare(sites[a].entrypoint, sites[b].entrypoint); });
+    } else {
+      indices.sort(function(a,b) {
+        return compare(sites[b].entrypoint, sites[a].entrypoint); });
+    }
+  }
 
   // ...clear existing list...
   var s = document.getElementById('site_listing');
@@ -344,6 +353,7 @@ function populate_station_list(sort_metric, sort_order) {
   buttons += create_buttons("Longitude", "longitude");
   buttons += create_buttons("Hardware", "station");
   buttons += create_buttons("Version", "weewx_info");
+  buttons += create_buttons("Entrypoint", "entrypoint");
   buttons += create_buttons("Last Seen", "last_seen");
   buttons += '<div class="button_pair">Thumbnails<br/><input type="checkbox" onClick="toggle_thumbnails()"';
   if (showThumbs) {

--- a/register/weereg.sql
+++ b/register/weereg.sql
@@ -80,7 +80,8 @@ CREATE TABLE `stations` (
   `config_path` varchar(128) DEFAULT NULL,
   `last_addr` varchar(16) DEFAULT NULL,
   `last_seen` int(11) DEFAULT NULL,
-  UNIQUE KEY `index_stations` (`station_url`,`latitude`,`longitude`,`station_type`,`station_model`,`weewx_info`,`python_info`,`platform_info`,`config_path`,`last_addr`)
+  UNIQUE KEY `index_url` (`station_url`),
+  KEY `index_addr` (`last_addr`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 

--- a/register/weereg.sql
+++ b/register/weereg.sql
@@ -77,10 +77,10 @@ CREATE TABLE `stations` (
   `weewx_info` varchar(64) DEFAULT NULL,
   `python_info` varchar(64) DEFAULT NULL,
   `platform_info` varchar(128) DEFAULT NULL,
-  `entrypoint` varchar(128) DEFAULT NULL,
+  `config_path` varchar(128) DEFAULT NULL,
   `last_addr` varchar(16) DEFAULT NULL,
   `last_seen` int(11) DEFAULT NULL,
-  UNIQUE KEY `index_stations` (`station_url`,`latitude`,`longitude`,`station_type`,`station_model`,`weewx_info`,`python_info`,`platform_info`,`entrypoint`,`last_addr`)
+  UNIQUE KEY `index_stations` (`station_url`,`latitude`,`longitude`,`station_type`,`station_model`,`weewx_info`,`python_info`,`platform_info`,`config_path`,`last_addr`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 

--- a/register/weereg.sql
+++ b/register/weereg.sql
@@ -77,9 +77,10 @@ CREATE TABLE `stations` (
   `weewx_info` varchar(64) DEFAULT NULL,
   `python_info` varchar(64) DEFAULT NULL,
   `platform_info` varchar(128) DEFAULT NULL,
+  `entrypoint` varchar(128) DEFAULT NULL,
   `last_addr` varchar(16) DEFAULT NULL,
   `last_seen` int(11) DEFAULT NULL,
-  UNIQUE KEY `index_stations` (`station_url`,`latitude`,`longitude`,`station_type`,`station_model`,`weewx_info`,`python_info`,`platform_info`,`last_addr`)
+  UNIQUE KEY `index_stations` (`station_url`,`latitude`,`longitude`,`station_type`,`station_model`,`weewx_info`,`python_info`,`platform_info`,`entrypoint`,`last_addr`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 


### PR DESCRIPTION
This is the backend PR to line up with the weewx restx.py changes in [weewx PR 705](https://github.com/weewx/weewx/pull/705), adding 'entrypoint' to the cgi and perl scripts to match.  If no entrypoint=/path/to/weewxd is entered, you should see a NULL in that field for the registered station.

Note - when you implement 'this' PR some manual updating of the registered stations db is needed to match the updated schema here.  Unfortunately my mysql-fu is sufficiently ancient that I didn't take a crack at it.   I guess do whatever you did the last time you added a field :-)

I didn't check the maps webpage that is generated, as it looked at a quick glance like several .js files are missing from the registration repo.  The db looks good and the various perl scripts seems to work ok for me on a pi.
