### PR TITLE
Fix some broken docs links.

### DIFF
--- a/.nginxy/footer.html
+++ b/.nginxy/footer.html
@@ -20,15 +20,15 @@
 <h2>Platform Packages</h2>
 <p>
   For Debian, Ubuntu, Mint, including Raspberry Pi, see:<br/>
-  <a href='http://weewx.com/docs/debian.htm'>http://weewx.com/docs/debian.htm</a>
+  <a href='http://weewx.com/docs/latest/debian.htm'>http://weewx.com/docs/latest/debian.htm</a>
 </p>
 <p>
-  For Redhat, CentOS, Fedora, see:<br/>
-  <a href='http://weewx.com/docs/redhat.htm'>http://weewx.com/docs/redhat.htm</a>
+  For Red Hat, CentOS, Fedora, see:<br/>
+  <a href='http://weewx.com/docs/latest/redhat.htm'>http://weewx.com/docs/latest/redhat.htm</a>
 </p>
 <p>
   For SuSE, OpenSuSE,see:<br/>
-  <a href='http://weewx.com/docs/suse.htm'>http://weewx.com/docs/suse.htm</a>
+  <a href='http://weewx.com/docs/latest/suse.htm'>http://weewx.com/docs/latest/suse.htm</a>
 </p>
 <p> The package files for each operating system are in the <a
 href='released_versions'>released_versions</a> directory, but it is typically easier to install them
@@ -39,11 +39,11 @@ directly from the platform repositories using the instructions listed above. </p
 method for those who write custom services and reports.</p>
 <p>
   For all operating systems including Linux, BSD, see:<br/>
-  <a href='http://weewx.com/docs/setup.htm'>http://weewx.com/docs/setup.htm</a>
+  <a href='http://weewx.com/docs/latest/setup.htm'>http://weewx.com/docs/latest/setup.htm</a>
 </p>
 <p>
   For MacOS, see:<br/>
-  <a href='http://weewx.com/docs/macos.htm'>http://weewx.com/docs/macos.htm</a>
+  <a href='http://weewx.com/docs/latest/macos.htm'>http://weewx.com/docs/latest/macos.htm</a>
 </p>
 
 <h2>Previous Releases</h2>
@@ -52,7 +52,7 @@ method for those who write custom services and reports.</p>
 <h2>Change History</h2>
 <p>
   The changes made in each release are included in the WeeWX documentation.<br/>
-  <a href='http://weewx.com/docs/changes.txt'>http://weewx.com/docs/changes.txt</a>
+  <a href='http://weewx.com/docs/latest/changes.txt'>http://weewx.com/docs/latest/changes.txt</a>
 </p>`;
 
     populate_header('downloads');

--- a/hardware.html
+++ b/hardware.html
@@ -70,7 +70,7 @@ hs.outlineType = 'rounded-white';
     <h2>Supported Hardware</h2>
     <p>
       WeeWX is known to work with the hardware shown on this page.
-      The <a href="docs/hardware.htm">Hardware Guide</a> has details
+      The <a href="docs/latest/hardware.htm">Hardware Guide</a> has details
       about driver capabilities and hardware quirks for drivers that
       are included in the WeeWX distribution.
       Additional drivers are listed in the

--- a/index.html
+++ b/index.html
@@ -58,7 +58,7 @@
             reports, and HTML pages. It can optionally publish to weather sites
             or web servers. It uses modern software concepts, making it simple,
             robust, and easy to extend. It includes extensive
-            <a href='docs'>documentation</a>.
+            <a href='/docs/latest/'>documentation</a>.
         </p>
         <p>
             WeeWX runs under most versions of Linux,

--- a/stations.html
+++ b/stations.html
@@ -815,7 +815,7 @@
 
         <div id='instructions'>
             <strong>How to Add Your Station</strong><br/>
-            Enable <a href='docs/usersguide.htm#station_registry'><span class='code'>register_this_station</span></a>
+            Enable <a href='docs/latest/usersguide.htm#station_registry'><span class='code'>register_this_station</span></a>
             in weewx.conf, then restart weeWX.
         </div>
 

--- a/support.html
+++ b/support.html
@@ -37,7 +37,7 @@
       </p>
       <p>You should have the following skills:</p>
       <ul>
-        <li>The patience to read and follow the <a href="../docs/usersguide.htm">User's Guide</a>;</li>
+        <li>The patience to read and follow the <a href="../docs/latest/usersguide.htm">User's Guide</a>;</li>
         <li>Willingness and ability to edit a configuration file;</li>
         <li>Some familiarity with Linux or other Unix derivatives;</li>
         <li>Know how to do simple Unix tasks like changing file


### PR DESCRIPTION
I tripped over a few 404s while looking at setting up weewx as a new user.

Looks like /docs/ redirects users to /docs/latest/, but links to pages within /docs/ do not, so they throw a 404—at least, until now. 👼 